### PR TITLE
allow for nodejs version up to 19 for SM distro >= 1.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sagemaker-code-editor" %}
-{% set version = "1.0.1" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -12,13 +12,13 @@ source:
   folder: sagemaker-code-editor
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not linux]
 
 requirements:
   build:
     # dependencies needed for open source microsoft/vscode - https://github.com/microsoft/vscode/wiki/How-to-Contribute 
-    - nodejs >=18.19.0,<18.20.0
+    - nodejs >=18.15,<19
     - yarn <2
     - make
     - pkg-config
@@ -33,7 +33,7 @@ requirements:
     - setuptools
   host:
     # dependencies needed for open source microsoft/vscode - https://github.com/microsoft/vscode/wiki/How-to-Contribute 
-    - nodejs >=18.19.0,<18.20.0
+    - nodejs >=18.15,<19
     - libxkbfile
     - xorg-libx11
     - krb5


### PR DESCRIPTION
**Description**

- allow for nodejs version up to 19

**Motivation**

we need a version of CE with the CVE updates as well as allowing the node version to go up to version 19 to allow for use in new sagemaker-distribution versions

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
