### PR TITLE
Pin nodejs to 18.18.2 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge sagemaker-code-editor_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   # github repo set-up is in progress, once ready we will use the github release url here instead of the s3 url
   url: https://sagemaker-code-editor-1696292125.s3.us-west-2.amazonaws.com/code-editor1.0.1.tar.gz
-  sha256: 86ce6d804d1656948ed666b69ffbf648d3c65eb7c57bfe3b6339925c30678c13
+  sha256: 8430cbc38b6a54814f970f2d23c8f5aa1fb7d3c26511c18d5f250d91f110230d
   folder: sagemaker-code-editor
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,13 +12,13 @@ source:
   folder: sagemaker-code-editor
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:
   build:
     # dependencies needed for open source microsoft/vscode - https://github.com/microsoft/vscode/wiki/How-to-Contribute 
-    - nodejs >=18.15,<19
+    - nodejs ==18.18.2
     - yarn <2
     - make
     - pkg-config
@@ -33,7 +33,7 @@ requirements:
     - setuptools
   host:
     # dependencies needed for open source microsoft/vscode - https://github.com/microsoft/vscode/wiki/How-to-Contribute 
-    - nodejs >=18.15,<19
+    - nodejs ==18.18.2
     - libxkbfile
     - xorg-libx11
     - krb5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,4 @@ extra:
     - aws-prayags
     - JedML
     - arkaprava08
+    - aws-pangestu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sagemaker-code-editor" %}
-{% set version = "1.0.1" %}
+{% set version = "1.0.1dev0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
For building into sagemaker-distribution 1.4 and 1.5 we need to pin NodeJS to 18.18.2

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
