### PR TITLE
Add swap file and space management back to pipelines definition

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,34 @@ jobs:
   variables: {}
 
   steps:
+  - script: |
+      sudo mkdir -p /opt/empty_dir || true
+      for d in \
+              /opt/ghc \
+              /opt/hostedtoolcache \
+              /usr/lib/jvm \
+              /usr/local/.ghcup \
+              /usr/local/lib/android \
+              /usr/local/share/powershell \
+              /usr/share/dotnet \
+              /usr/share/swift \
+              ; do
+       sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+      done
+      sudo apt-get purge -y -f firefox \
+                              google-chrome-stable \
+                              microsoft-edge-stable
+      sudo apt-get autoremove -y >& /dev/null
+      sudo apt-get autoclean -y >& /dev/null
+      df -h
+    displayName: Manage disk space
+  # This creates swap file that creates temporary memory space when the system runs low on memory
+  - script: |
+      sudo fallocate -l 10GiB /swapfile || true
+      sudo chmod 600 /swapfile || true
+      sudo mkswap /swapfile || true
+      sudo swapon /swapfile || true
+    displayName: Create swap file
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |


### PR DESCRIPTION
Add back the swap file and space management to fix OOM issue during pipelines build that causes SIGKILL. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

