### PR TITLE
Add aakashmandavilli96 to recipe maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,7 @@ extra:
   recipe-maintainers:
     - aws-prayags
     - arkaprava08
+    - aakashmandavilli96
     - aws-pangestu
     - navinsoni
     - sgganjo


### PR DESCRIPTION
## Summary
Adding aakashmandavilli96 to the list of recipe maintainers.

## Changes
- Updated recipe maintainers list to include aakashmandavilli96

## Checklist
- [x] Added maintainer to recipe
- [x] Followed conda-forge contribution guidelines