### PR TITLE
Release 1.5.1 patch version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 # This code includes code from https://github.com/conda-forge/openvscode-server-feedstock 
 # which is licensed under the BSD-3-Clause License.
 
-pushd sagemaker-code-editor
+pushd code-editor1.5.1
 pushd src
 
 # Fix error 'Check failed: current == end_slot_index.' while running 'yarn list --prod --json'
@@ -13,6 +13,10 @@ pushd src
 # See https://github.com/nodejs/node/issues/51555
 
 export DISABLE_V8_COMPILE_CACHE=1
+
+# Limit Node.js memory usage to prevent OOM kills
+export NODE_OPTIONS="--max-old-space-size=4096"
+export UV_THREADPOOL_SIZE=4
 
 # Install node-gyp globally as a fix for NodeJS 18.18.2 https://github.com/microsoft/vscode/issues/194665
 npm i -g node-gyp
@@ -22,7 +26,7 @@ VSCODE_RIPGREP_VERSION=$(jq -r '.dependencies."@vscode/ripgrep"' package.json)
 mv package.json package.json.orig
 jq 'del(.dependencies."@vscode/ripgrep")' package.json.orig > package.json
 
-yarn install
+yarn install --network-concurrency 1
 
 # Install @vscode/ripgrep without downloading the pre-built ripgrep.
 # This often runs into Github API ratelimits and we won't use the binary in this package anyways.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,22 @@
 {% set name = "sagemaker-code-editor" %}
-{% set version = "1.6.1" %}
+{% set version = "1.5.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://github.com/aws/sagemaker-code-editor/releases/download/v1.6.1/code-editorv1.6.1.tar.gz
-  sha256: 2fa5e00a9a1247b334e4584b93ac64dfc51dd6cf62055953a73831b4faff1bc2
-  folder: sagemaker-code-editor
+  url: https://github.com/aws/sagemaker-code-editor/releases/download/v1.5.1/code-editor1.5.1.tar.gz
+  sha256: c22897805d7a779d340819e94d5f585c35b977002a12d01d78262e4678d62d62
+  folder: code-editor1.5.1
 
 build:
   number: 0
   skip: true  # [not linux]
+  # Request more build resources
+  script_env:
+    - NODE_OPTIONS=--max-old-space-size=4096
+    - UV_THREADPOOL_SIZE=4
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged) - Instead we are 1:1 with https://github.com/aws/sagemaker-code-editor/ using 1.5.1
* [ ] Reset the build number to `0` (if the version changed) - Instead we are 1:1 with https://github.com/aws/sagemaker-code-editor/ using 1.5.1
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.
-->

Unsure which checkboxes above I need for this change 

## PR Summary

- Update version from 1.6.1 to 1.5.1
- Add memory optimizations to prevent build failures:
  - Limit Node.js heap size to 2GB (Node ate too much memory in previous PRs even with no changes, ex: https://github.com/conda-forge/sagemaker-code-editor-feedstock/pull/83)
  - Reduce thread pool size to 2
  - Disable webpack parallelization
  - Limit yarn network concurrency
- Tested successfully in CodeBuild environment as well

Fixes build failures caused by memory exhaustion during webpack bundling step.
