### PR TITLE
Create a new release candidate for 1.8.0b8 based on aws/code-editor 1.0.2-rc.1

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: sagemaker-code-editor
-  version: "1.8.0b7"
+  version: "1.8.0b8"
 
 package:
   name: ${{ name|lower }}
@@ -11,8 +11,8 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://github.com/aws/code-editor/releases/download/1.0.1/code-editor-sagemaker-server-1.0.1.tar.gz
-      sha256: 73222058d751fa7a097f9361015e93671871077f33c0055e3ebb38eb261e31ad
+      url: https://github.com/aws/code-editor/releases/download/1.0.2-rc.1/code-editor-sagemaker-server-1.0.2-rc.1.tar.gz
+      sha256: 678d551acfebe7876f20103ebc20d1c092331c7272fac2993ebfdc52308ca0ae
       target_directory: vscode-reh-web-linux-x64
 
 build:


### PR DESCRIPTION
**Description**
- Create a new release candidate for 1.8.0b7 based on AWS/CodeEditor

**Motivation**
- AWS/CodeEditor integration check, which now includes the `sagemaker-idle-extension` fix Terminal processes.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
