### PR TITLE
feat(recipe): Update Code Editor to 1.2.0-rc.1

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: sagemaker-code-editor
-  version: "1.9.7"
+  version: "1.10.0"
 
 package:
   name: ${{ name|lower }}
@@ -11,8 +11,8 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://github.com/aws/code-editor/releases/download/1.1.8/code-editor-sagemaker-server-1.1.8.tar.gz
-      sha256: 34d87fef78cc12d87cd4575f94d8722ca99f241db546f332f6cf38ce8e95005f
+      url: https://github.com/aws/code-editor/releases/download/1.2.0-rc.1/code-editor-sagemaker-server-1.2.0-rc.1.tar.gz
+      sha256: ec8e866e7a8d35c768e3be2ed0a84f03d62a454874a1464bc8119b986e115c89
       target_directory: vscode-reh-web-linux-x64
 
 build:
@@ -28,9 +28,9 @@ requirements:
     - ${{ compiler('cxx') }}
     - ${{ stdlib("c") }}
   host:
-    - nodejs 20.19.*
+    - nodejs 22.22.*
   run:
-    - nodejs 20.19.*
+    - nodejs 22.22.*
 
 tests:
   - script:


### PR DESCRIPTION
## Summary
Update sagemaker-code-editor to use the new `1.2.0-rc.1` release from `aws/code-editor`.

## Changes
- Source URL: `code-editor-sagemaker-server-1.2.0-rc.1.tar.gz` from [1.2.0-rc.1 release](https://github.com/aws/code-editor/releases/tag/1.2.0-rc.1)
- Node.js bumped from 20.19.x to 22.22.x (matches bundled Node in the release)
- Repository URL updated to `aws/code-editor`

## Context
This is a pre-release candidate for testing. The release upgrades VS Code base from 1.108.2 to 1.119.1.

cc @aakashmandavilli96 @sgganjo