### PR TITLE
feat(recipe): Update Code Editor to 1.1.9

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: sagemaker-code-editor
-  version: "1.9.7"
+  version: "1.9.8"
 
 package:
   name: ${{ name|lower }}
@@ -11,8 +11,8 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://github.com/aws/code-editor/releases/download/1.1.8/code-editor-sagemaker-server-1.1.8.tar.gz
-      sha256: 34d87fef78cc12d87cd4575f94d8722ca99f241db546f332f6cf38ce8e95005f
+      url: https://github.com/aws/code-editor/releases/download/1.1.9/code-editor-sagemaker-server-1.1.9.tar.gz
+      sha256: f306634d8075be5bfb61aa5a71d05fa3a5b8529df97231c1405d42c7cf2c4257
       target_directory: vscode-reh-web-linux-x64
 
 build:


### PR DESCRIPTION
- Bump sagemaker-code-editor version to 1.9.8
- Update Code Editor to 1.1.9 (extension symlink persistence fix)
- Source: https://github.com/aws/code-editor/releases/tag/1.1.9
