### PR TITLE
feat(recipe): Update Code Editor to 1.2.0-rc.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,8 +34,8 @@ fi
 # Move one level up to reach the conda environment prefix.
 PREFIX_DIR=$(dirname "${PREFIX_DIR}")
 
-# Start the server using Node.js, passing all user arguments.
-node "${PREFIX_DIR}/share/sagemaker-code-editor/out/server-main.js" "$@"
+# Start the server using the bundled Node.js, passing all user arguments.
+"${PREFIX_DIR}/share/sagemaker-code-editor/node" "${PREFIX_DIR}/share/sagemaker-code-editor/out/server-main.js" "$@"
 EOF
 
 chmod +x "${PREFIX}/bin/sagemaker-code-editor"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: sagemaker-code-editor
-  version: "1.8.8b1"
+  version: "1.10.0b1"
 
 package:
   name: ${{ name|lower }}
@@ -11,8 +11,8 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://github.com/aws/code-editor/releases/download/1.0.10/code-editor-sagemaker-server-1.0.10.tar.gz
-      sha256: f1c95109b02e28feb989ad6a36789b66e4916f5a5db12047e7d3a9f4a8e352a9
+      url: https://github.com/aws/code-editor/releases/download/1.2.0-rc.1/code-editor-sagemaker-server-1.2.0-rc.1.tar.gz
+      sha256: ec8e866e7a8d35c768e3be2ed0a84f03d62a454874a1464bc8119b986e115c89
       target_directory: vscode-reh-web-linux-x64
 
 build:


### PR DESCRIPTION
- Bump sagemaker-code-editor version to 1.10.0b1
- Update Code Editor to 1.2.0-rc.1 (VS Code 1.119.1)
- Use bundled Node.js in launcher (required — CE 1.2.x needs Node 22.15+, system node is 20.x)
- Source: https://github.com/aws/code-editor/releases/tag/1.2.0-rc.1

Tested locally: CE starts cleanly, extension host starts, bundled node v22.22.1 confirmed.

cc @aakashmandavilli96