### PR TITLE
fix(build): Remove bundled unused dependencies

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,12 @@ cp -a ./* "${PREFIX}/share/sagemaker-code-editor"
 # Clean up unnecessary files to reduce package size
 find "${PREFIX}/share/sagemaker-code-editor" -name '*.map' -delete
 
+# Remove bundled GitHub Copilot binaries (not used in SageMaker Code Editor)
+# Keep @github/copilot-sdk as it's imported by agentHostMain.js
+# See: https://github.com/aws/code-editor/issues/266
+rm -rf "${PREFIX}/share/sagemaker-code-editor/node_modules/@github/copilot"
+rm -rf "${PREFIX}/share/sagemaker-code-editor/node_modules/@github/copilot-linuxmusl-x64"
+
 # Create the binary entry point script for sagemaker-code-editor.
 mkdir -p "${PREFIX}/bin"
 cat <<'EOF' >"${PREFIX}/bin/sagemaker-code-editor"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -19,7 +19,7 @@ build:
   skip:
     - win
     - osx and x86_64
-  number: 0
+  number: 1
   dynamic_linking:
     binary_relocation: false
 


### PR DESCRIPTION
Remove unused `@github/copilot` and `@github/copilot-linuxmusl-x64` from `node_modules/` during packaging.

`@github/copilot-sdk` is kept because `agentHostMain.js` imports it at module load time.

Upstream issue: https://github.com/aws/code-editor/issues/266