### PR TITLE
Update Code Editor to 1.2.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,12 @@ cp -a ./* "${PREFIX}/share/sagemaker-code-editor"
 # Clean up unnecessary files to reduce package size
 find "${PREFIX}/share/sagemaker-code-editor" -name '*.map' -delete
 
+# Remove bundled GitHub Copilot binaries (not used in SageMaker Code Editor)
+# Keep @github/copilot-sdk as it's imported by agentHostMain.js
+# See: https://github.com/aws/code-editor/issues/266
+rm -rf "${PREFIX}/share/sagemaker-code-editor/node_modules/@github/copilot"
+rm -rf "${PREFIX}/share/sagemaker-code-editor/node_modules/@github/copilot-linuxmusl-x64"
+
 # Create the binary entry point script for sagemaker-code-editor.
 mkdir -p "${PREFIX}/bin"
 cat <<'EOF' >"${PREFIX}/bin/sagemaker-code-editor"
@@ -34,8 +40,8 @@ fi
 # Move one level up to reach the conda environment prefix.
 PREFIX_DIR=$(dirname "${PREFIX_DIR}")
 
-# Start the server using Node.js, passing all user arguments.
-node "${PREFIX_DIR}/share/sagemaker-code-editor/out/server-main.js" "$@"
+# Start the server using the bundled Node.js, passing all user arguments.
+"${PREFIX_DIR}/share/sagemaker-code-editor/node" "${PREFIX_DIR}/share/sagemaker-code-editor/out/server-main.js" "$@"
 EOF
 
 chmod +x "${PREFIX}/bin/sagemaker-code-editor"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: sagemaker-code-editor
-  version: "1.9.8"
+  version: "1.10.0"
 
 package:
   name: ${{ name|lower }}
@@ -11,8 +11,8 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://github.com/aws/code-editor/releases/download/1.1.9/code-editor-sagemaker-server-1.1.9.tar.gz
-      sha256: f306634d8075be5bfb61aa5a71d05fa3a5b8529df97231c1405d42c7cf2c4257
+      url: https://github.com/aws/code-editor/releases/download/1.2.0/code-editor-sagemaker-server-1.2.0.tar.gz
+      sha256: 0278e062edee07b482eede582f0a0f093d311f7d70812bab8a4302f1ec4f9dcb
       target_directory: vscode-reh-web-linux-x64
 
 build:


### PR DESCRIPTION
Update to CE 1.2.0 (VS Code 1.119.1).

- Use bundled Node.js (CE 1.2.0+ requires Node 22)
- Remove unused `@github/copilot` and `@github/copilot-linuxmusl-x64`
- Keep `@github/copilot-sdk` (imported by `agentHostMain.js`)

See: https://github.com/aws/code-editor/issues/266